### PR TITLE
Add config option to change overload timer color x ticks ahead of the restore tick

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.8.19'
+def runeLiteVersion = '1.8.29'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/net/runelite/client/plugins/bettertimers/BetterOverloadConfig.java
+++ b/src/main/java/net/runelite/client/plugins/bettertimers/BetterOverloadConfig.java
@@ -28,4 +28,15 @@ public interface BetterOverloadConfig extends Config
 	{
 		return BetterOverloadMode.SECONDS;
 	}
+
+	@ConfigItem(
+			keyName = "brewWarningTicks",
+			name = "Brew Warning Ticks",
+			description = "Shows the timer in yellow this many ticks ahead of the overload restore tick. Set to 0 to disable.",
+			position = 3
+	)
+	default int brewWarningTicks()
+	{
+		return 0;
+	}
 }

--- a/src/main/java/net/runelite/client/plugins/bettertimers/BetterOverloadInfoBox.java
+++ b/src/main/java/net/runelite/client/plugins/bettertimers/BetterOverloadInfoBox.java
@@ -52,6 +52,9 @@ public class BetterOverloadInfoBox extends InfoBox
 		{
 			return Color.RED;
 		}
+		else if (plugin.overloadInTicks % 25 < config.brewWarningTicks()) {
+			return Color.YELLOW;
+		}
 		return Color.WHITE;
 	}
 


### PR DESCRIPTION
Implements https://github.com/tdb48/better-timers/issues/1. Useful for plebs like myself that aren't always great at brewing on the exact tick, and gives an indication of when a decent time to brew right before it.

I had to update the runlite version for testing (otherwise client shows an error of "runelite has not been updated"); not sure if it's needed for users (I'm guessing they are updating runelite as well each game update, but can remove that from the PR if needed).

Tested this, confirmed following functionality:

1. Setting the config to 0 means the timer never shows as yellow.
2. Setting the config to any non-zero shows timer in yellow on appropriate ticks.
3. Confirmed that with the config set to non-zero, the restore tick still shows as green.
4. Confirmed that when the overload timer is past the last restore (<25 ticks left on the overload), the timer still shows as red.