### PR TITLE
Feature: Repeating Ticks

### DIFF
--- a/src/main/java/net/runelite/client/plugins/bettertimers/BetterOverloadConfig.java
+++ b/src/main/java/net/runelite/client/plugins/bettertimers/BetterOverloadConfig.java
@@ -1,5 +1,7 @@
 package net.runelite.client.plugins.bettertimers;
 
+import java.awt.Color;
+
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
@@ -7,7 +9,8 @@ import net.runelite.client.config.ConfigItem;
 @ConfigGroup("beanLoad")
 public interface BetterOverloadConfig extends Config
 {
-
+	final Color BREW_TICK_COLOR = new Color(26, 204, 6);
+ 
 	@ConfigItem(
 		keyName = "brewTick",
 		name = "Show brew tick",
@@ -60,5 +63,21 @@ public interface BetterOverloadConfig extends Config
 	default boolean enableMenaphiteRemedy()
 	{
 		return true;
+	}
+
+	default Color getTextColor(int ticks)
+	{
+		if (ticks % 25 == 0 && this.brewTick())
+		{
+			return BREW_TICK_COLOR;
+		}
+		else if (ticks < 25)
+		{
+			return Color.RED;
+		}
+		else if (ticks % 25 < this.brewWarningTicks()) {
+			return Color.YELLOW;
+		}
+		return Color.WHITE;
 	}
 }

--- a/src/main/java/net/runelite/client/plugins/bettertimers/BetterOverloadInfoBox.java
+++ b/src/main/java/net/runelite/client/plugins/bettertimers/BetterOverloadInfoBox.java
@@ -25,37 +25,13 @@ public class BetterOverloadInfoBox extends InfoBox
 	@Override
 	public String getText()
 	{
-		String str;
-		if (config.overloadMode() == BetterOverloadMode.TICKS)
-		{
-			str = String.valueOf(plugin.overloadInTicks);
-		}
-		else if (config.overloadMode() == BetterOverloadMode.DECIMALS)
-		{
-			str = BetterOverloadPlugin.to_mmss_precise_short(plugin.overloadInTicks);
-		}
-		else
-		{
-			str = BetterOverloadPlugin.to_mmss(plugin.overloadInTicks);
-		}
-		return str;
+		return config.overloadMode().format(plugin.overloadInTicks);
 	}
 
 	@Override
 	public Color getTextColor()
 	{
-		if (plugin.overloadInTicks % 25 == 0 && config.brewTick())
-		{
-			return new Color(26, 204, 6);
-		}
-		else if (plugin.overloadInTicks < 25)
-		{
-			return Color.RED;
-		}
-		else if (plugin.overloadInTicks % 25 < config.brewWarningTicks()) {
-			return Color.YELLOW;
-		}
-		return Color.WHITE;
+		return config.getTextColor(plugin.overloadInTicks);
 	}
 
 	@Override

--- a/src/main/java/net/runelite/client/plugins/bettertimers/BetterOverloadMenaphiteRemedyInfoBox.java
+++ b/src/main/java/net/runelite/client/plugins/bettertimers/BetterOverloadMenaphiteRemedyInfoBox.java
@@ -24,37 +24,13 @@ public class BetterOverloadMenaphiteRemedyInfoBox extends InfoBox
     @Override
     public String getText()
     {
-        String str;
-        if (config.overloadMode() == BetterOverloadMode.TICKS)
-        {
-            str = String.valueOf(plugin.menaphiteRemedyInTicks);
-        }
-        else if (config.overloadMode() == BetterOverloadMode.DECIMALS)
-        {
-            str = BetterOverloadPlugin.to_mmss_precise_short(plugin.menaphiteRemedyInTicks);
-        }
-        else
-        {
-            str = BetterOverloadPlugin.to_mmss(plugin.menaphiteRemedyInTicks);
-        }
-        return str;
+		return config.overloadMode().format(plugin.menaphiteRemedyInTicks);
     }
 
     @Override
     public Color getTextColor()
     {
-        if (plugin.menaphiteRemedyInTicks % 25 == 0 && config.brewTick())
-        {
-            return new Color(26, 204, 6);
-        }
-        else if (plugin.menaphiteRemedyInTicks < 25)
-        {
-            return Color.RED;
-        }
-        else if (plugin.menaphiteRemedyInTicks % 25 < config.brewWarningTicks()) {
-            return Color.YELLOW;
-        }
-        return Color.WHITE;
+		return config.getTextColor(plugin.menaphiteRemedyInTicks);
     }
 
     @Override

--- a/src/main/java/net/runelite/client/plugins/bettertimers/BetterOverloadMode.java
+++ b/src/main/java/net/runelite/client/plugins/bettertimers/BetterOverloadMode.java
@@ -1,8 +1,23 @@
 package net.runelite.client.plugins.bettertimers;
 
-public enum BetterOverloadMode
-{
+public enum BetterOverloadMode {
 	TICKS,
 	SECONDS,
-	DECIMALS
+	DECIMALS,
+	REPEATING_TICKS;
+
+	public String format(int ticks) {
+		switch (this) {
+			case TICKS:
+				return String.valueOf(ticks);
+			case SECONDS:
+				return BetterOverloadPlugin.to_mmss(ticks);
+			case DECIMALS:
+				return BetterOverloadPlugin.to_mmss_precise_short(ticks);
+			case REPEATING_TICKS:
+				return String.valueOf(ticks % 25);
+			default:
+				return BetterOverloadPlugin.to_mmss(ticks);
+		}
+	}
 }

--- a/src/main/java/net/runelite/client/plugins/bettertimers/BetterOverloadSaltInfoBox.java
+++ b/src/main/java/net/runelite/client/plugins/bettertimers/BetterOverloadSaltInfoBox.java
@@ -24,37 +24,13 @@ public class BetterOverloadSaltInfoBox extends InfoBox
 	@Override
 	public String getText()
 	{
-		String str;
-		if (config.overloadMode() == BetterOverloadMode.TICKS)
-		{
-			str = String.valueOf(plugin.saltInTicks);
-		}
-		else if (config.overloadMode() == BetterOverloadMode.DECIMALS)
-		{
-			str = BetterOverloadPlugin.to_mmss_precise_short(plugin.saltInTicks);
-		}
-		else
-		{
-			str = BetterOverloadPlugin.to_mmss(plugin.saltInTicks);
-		}
-		return str;
+		return config.overloadMode().format(plugin.saltInTicks);
 	}
 
 	@Override
 	public Color getTextColor()
 	{
-		if (plugin.saltInTicks % 25 == 0 && config.brewTick())
-		{
-			return new Color(26, 204, 6);
-		}
-		else if (plugin.saltInTicks < 25)
-		{
-			return Color.RED;
-		}
-		else if (plugin.saltInTicks % 25 < config.brewWarningTicks()) {
-			return Color.YELLOW;
-		}
-		return Color.WHITE;
+		return config.getTextColor(plugin.saltInTicks);
 	}
 
 	@Override


### PR DESCRIPTION
Adds a config option to display just the remaining ticks until the next stat restore happens, similar to the prayer enhance timer in cox additions.

Additionally removes some repeating code and centralizes the logic